### PR TITLE
Fix: MailIcon y NotificationsIcon funcionan en todo admin

### DIFF
--- a/src/admin/components/ListReviewsPublished.jsx
+++ b/src/admin/components/ListReviewsPublished.jsx
@@ -1,19 +1,30 @@
 import { Box, Typography, IconButton } from '@mui/material'
 import { DataGrid } from '@mui/x-data-grid'
-import { useGetReviewsQuery } from '../../store/api/ecommerceReviewApi'
+import { useGetDeactivedReviewsQuery, useGetReviewsQuery } from '../../store/api/ecommerceReviewApi'
 import { useGetProductsQuery } from '../../hooks/useGetProductsByIdsQuery'
 import { useBlockReviewMutation } from '../../store/api/ecommerceReviewApi'
+import { setReviewsCount } from '../../store/adminNotifications/notificationsSlice'
 import { useNavigate } from 'react-router-dom'
+import { useDispatch } from 'react-redux'
+import { useEffect } from 'react'
 import BlockIcon from '@mui/icons-material/Block'
 import Swal from 'sweetalert2'
 
 export const ListReviewsPublished = () => {
 
-    const { data: reviews = [], error, isLoading, refetch } = useGetReviewsQuery()
+    const { data: reviews = [], error, isLoading } = useGetReviewsQuery()
+    const { data: reviewsDeactived = [], errorDeactives, isLoadingDeactived, refetch } = useGetDeactivedReviewsQuery()
     const idProductReview = [...new Set(reviews.map(review => review.idProduct))]
     const { data: products = [], error: errorProduct, isLoading: isLoadingProduct } = useGetProductsQuery(idProductReview)
     const [blockReview] = useBlockReviewMutation()
     const navigate = useNavigate()
+    const dispatch = useDispatch()
+
+    useEffect(() => {
+        const count = reviewsDeactived.length;
+        dispatch(setReviewsCount(count));
+        refetch()
+    }, [reviewsDeactived, reviews])
 
     const handleBlock = async(id) => {
         await blockReview(id)

--- a/src/admin/components/NavbarAdmin.jsx
+++ b/src/admin/components/NavbarAdmin.jsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useState, useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import { 
   AppBar, 
   Box, 
@@ -18,6 +18,9 @@ import {
   MoreVert      as MoreIcon 
 } from '@mui/icons-material';
 import { Link } from 'react-router-dom';
+import { useGetDeactivedReviewsQuery } from '../../store/api/ecommerceReviewApi';
+import { useGetQuestionsQuery } from '../../store/api/ecommerceQuestionsApi';
+import { setReviewsCount, setUnansweredCount } from '../../store/adminNotifications/notificationsSlice';
 
 export const NavbarAdmin = ({drawerWith, handleDrawerToggle}) => {
     const [anchorEl, setAnchorEl] = useState(null);
@@ -27,6 +30,18 @@ export const NavbarAdmin = ({drawerWith, handleDrawerToggle}) => {
 
     const isMenuOpen = Boolean(anchorEl);
     const isMobileMenuOpen = Boolean(mobileMoreAnchorEl);
+
+    const { data: reviews = [], error, isLoading, refetch } = useGetDeactivedReviewsQuery()
+    const { data: questions = [], errorQuestions, isLoadingQuestions, refetchQuestions } = useGetQuestionsQuery()
+    const dispatch = useDispatch()
+
+    useEffect(() => {
+      const count = reviews.length;
+      const unansweredCount = questions.filter(question => !question.responseComments).length;
+      dispatch(setReviewsCount(count));
+      dispatch(setUnansweredCount(unansweredCount));
+      refetch()
+    }, [reviews, questions])
 
     const handleProfileMenuOpen = (event) => {
         setAnchorEl(event.currentTarget);
@@ -92,7 +107,7 @@ export const NavbarAdmin = ({drawerWith, handleDrawerToggle}) => {
                 size="large" 
                 aria-label="show 4 new mails" 
                 color="inherit">
-                <Badge badgeContent={notifications.unansweredCount} color="error">
+                <Badge badgeContent={notifications?.unansweredCount} color="error">
                     <MailIcon />
                 </Badge>
               </IconButton>
@@ -105,7 +120,7 @@ export const NavbarAdmin = ({drawerWith, handleDrawerToggle}) => {
               aria-label="show 17 new notifications"
               color="inherit"
               >
-              <Badge badgeContent={notifications.reviewsCount} color="error">
+              <Badge badgeContent={notifications?.reviewsCount} color="error">
                   <NotificationsIcon />
               </Badge>
               </IconButton>


### PR DESCRIPTION
Los iconos que cuantifican las preguntas sin responder y las reviews sin atender (o resolver) funcionan en todo el panel admin